### PR TITLE
Remove usage of Task.setName, deprecated in Gradle 2.14, removed for 3.0

### DIFF
--- a/src/main/java/fr/putnami/gwt/gradle/task/GwtCheckTask.java
+++ b/src/main/java/fr/putnami/gwt/gradle/task/GwtCheckTask.java
@@ -44,7 +44,6 @@ public class GwtCheckTask extends AbstractTask {
 	private File war;
 
 	public GwtCheckTask() {
-		setName(NAME);
 		setDescription("Check the GWT modules");
 
 		dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaPlugin.PROCESS_RESOURCES_TASK_NAME);

--- a/src/main/java/fr/putnami/gwt/gradle/task/GwtCodeServerTask.java
+++ b/src/main/java/fr/putnami/gwt/gradle/task/GwtCodeServerTask.java
@@ -29,7 +29,6 @@ public class GwtCodeServerTask extends AbstractTask {
 	public static final String NAME = "gwtCodeServer";
 
 	public GwtCodeServerTask() {
-		setName(NAME);
 		setDescription("Run CodeServer in SuperDevMode");
 
 		dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaPlugin.PROCESS_RESOURCES_TASK_NAME);

--- a/src/main/java/fr/putnami/gwt/gradle/task/GwtCompileTask.java
+++ b/src/main/java/fr/putnami/gwt/gradle/task/GwtCompileTask.java
@@ -46,7 +46,6 @@ public class GwtCompileTask extends AbstractTask {
 	private FileCollection src;
 
 	public GwtCompileTask() {
-		setName(NAME);
 		setDescription("Compile the GWT modules");
 
 		dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaPlugin.PROCESS_RESOURCES_TASK_NAME);

--- a/src/main/java/fr/putnami/gwt/gradle/task/GwtDevTask.java
+++ b/src/main/java/fr/putnami/gwt/gradle/task/GwtDevTask.java
@@ -51,7 +51,6 @@ public class GwtDevTask extends AbstractTask {
 	private File jettyConf;
 
 	public GwtDevTask() {
-		setName(NAME);
 		setDescription("Run DevMode");
 
 		dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaPlugin.PROCESS_RESOURCES_TASK_NAME);

--- a/src/main/java/fr/putnami/gwt/gradle/task/GwtRunTask.java
+++ b/src/main/java/fr/putnami/gwt/gradle/task/GwtRunTask.java
@@ -37,7 +37,6 @@ public class GwtRunTask extends AbstractTask {
 	private File jettyConf;
 
 	public GwtRunTask() {
-		setName(NAME);
 		setDescription("Run jetty with the GW the GWT modules");
 
 		dependsOn(WarPlugin.WAR_TASK_NAME);

--- a/src/main/java/fr/putnami/gwt/gradle/task/GwtSetUpTask.java
+++ b/src/main/java/fr/putnami/gwt/gradle/task/GwtSetUpTask.java
@@ -36,7 +36,6 @@ public class GwtSetUpTask extends AbstractTask {
 	private List<String> modules;
 
 	public GwtSetUpTask() {
-		setName(NAME);
 		setDescription("Set up the GWT project from a skeleton");
 	}
 

--- a/src/main/java/fr/putnami/gwt/gradle/task/GwtStopTask.java
+++ b/src/main/java/fr/putnami/gwt/gradle/task/GwtStopTask.java
@@ -27,7 +27,6 @@ public class GwtStopTask extends AbstractTask {
 	public static final String NAME = "gwtStop";
 
 	public GwtStopTask() {
-		setName(NAME);
 		setDescription("Stop jetty");
 	}
 


### PR DESCRIPTION
Deprecation https://github.com/gradle/gradle/commit/6a57758
Removal https://github.com/gradle/gradle/commit/0647d36

The tasks are properly named by PwtPlugin already.