### PR TITLE
Fixed compile configurations

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip

--- a/samples/pgp-sample-lib/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/pgp-sample-lib/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip

--- a/src/main/java/fr/putnami/gwt/gradle/helper/CodeServerBuilder.java
+++ b/src/main/java/fr/putnami/gwt/gradle/helper/CodeServerBuilder.java
@@ -98,7 +98,7 @@ public class CodeServerBuilder extends JavaCommandBuilder {
 
 	private Collection<File> listProjectDepsSrcDirs(Project project) {
 		ConfigurationContainer configs = project.getConfigurations();
-		Configuration compileConf = configs.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME);
+		Configuration compileConf = configs.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
 		DependencySet depSet = compileConf.getAllDependencies();
 
 		List<File> result = Lists.newArrayList();

--- a/src/main/java/fr/putnami/gwt/gradle/helper/CompileCommandBuilder.java
+++ b/src/main/java/fr/putnami/gwt/gradle/helper/CompileCommandBuilder.java
@@ -35,7 +35,7 @@ public class CompileCommandBuilder extends JavaCommandBuilder {
 	public void configure(Project project, CompilerOption compilerOptions, FileCollection sources, File war,
 		Collection<String> modules) {
 		Configuration sdmConf = project.getConfigurations().getByName(PwtLibPlugin.CONF_GWT_SDM);
-		Configuration compileConf = project.getConfigurations().getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME);
+		Configuration compileConf = project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
 
 		configureJavaArgs(compilerOptions);
 		addJavaArgs("-Dgwt.persistentunitcachedir=" + project.getBuildDir() + "/putnami/work/cache");


### PR DESCRIPTION
@fdumay 
My apologies, I sent you bad code that you merged. This breaks the released 0.6.0 - you may have to do 0.6.1 or 0.7.0, but you should remove 0.6.0.
 
I was trying to fix some deprecated configuration and put the wrong ones.
I corrected them and tested it on my project before re-submitting the patch.

Sorry about that.