### PR TITLE
Fix for issue #64: modern remote debugging arguments

### DIFF
--- a/src/main/java/fr/putnami/gwt/gradle/helper/JavaCommandBuilder.java
+++ b/src/main/java/fr/putnami/gwt/gradle/helper/JavaCommandBuilder.java
@@ -153,7 +153,7 @@ public abstract class JavaCommandBuilder {
 		}
 		if (javaOptions.isDebugJava()) {
 			StringBuilder sb = new StringBuilder();
-			sb.append("-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=");
+			sb.append("-agentlib:jdwp=server=y,transport=dt_socket,address=");
 			sb.append(javaOptions.getDebugPort());
 			sb.append(",suspend=");
 			sb.append(javaOptions.isDebugSuspend() ? "y" : "n");


### PR DESCRIPTION
Use modern remote debugging arguments in Java invocation.