### PR TITLE
Github markdown rendering fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##This project is no longer maintained
+## This project is no longer maintained
 
 >**A fork of it that is still supported and has a newer release is available at https://github.com/esoco/gwt-gradle-plugin. Please use the new version if you need GWT support for Gradle.**  
 


### PR DESCRIPTION
Fixed a rendering error in the readme change, just a missing space - Github renders markdown differently as my preview...